### PR TITLE
Update VulkanHelper to support surface creation on macOS

### DIFF
--- a/SPB/Graphics/Vulkan/VulkanHelper.cs
+++ b/SPB/Graphics/Vulkan/VulkanHelper.cs
@@ -19,21 +19,21 @@ namespace SPB.Graphics.Vulkan
 
         private static IntPtr _vulkanHandle;
 
-        // Platform specific library hints
-        // Win32
+        // Platform specific library hints.
+        // For Win32:
         private static readonly string[] VulkanLibraryNameWindows =
         {
             "vulkan-1.dll"
         };
 
-        // Linux
+        // For Linux:
         private static readonly string[] VulkanLibraryNameLinux =
         {
             "libvulkan.so.1"
         };
 
-        // macOS: try MoltenVK first (see: https://github.com/KhronosGroup/MoltenVK),
-        // then try libvulkan as a last chance option
+        // For macOS: try MoltenVK first (see: https://github.com/KhronosGroup/MoltenVK),
+        // then try libvulkan as a last chance option.
         private static readonly string[] VulkanLibraryNameMacOS =
         {
             "libMoltenVk.dylib",
@@ -53,7 +53,7 @@ namespace SPB.Graphics.Vulkan
             public uint SpecVersion;
         }
 
-        // Extensions related structure type IDs
+        // Extensions related structure type IDs.
         // See: https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_core.h
         private const uint VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR = 1000004000;
         private const uint VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR = 1000005000;
@@ -161,7 +161,7 @@ namespace SPB.Graphics.Vulkan
                 return false;
             }
 
-            // return on the first successfully loaded library
+            // Returns on the first successfully loaded library.
             foreach (var libraryName in libraryNameHints)
             {
                 if (NativeLibrary.TryLoad(libraryName, out vulkanHandle))

--- a/SPB/Graphics/Vulkan/VulkanHelper.cs
+++ b/SPB/Graphics/Vulkan/VulkanHelper.cs
@@ -6,8 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
+using SPB.Platform.Cocoa;
 
 namespace SPB.Graphics.Vulkan
 {
@@ -17,9 +19,26 @@ namespace SPB.Graphics.Vulkan
 
         private static IntPtr _vulkanHandle;
 
-        private const string VulkanLibraryNameWindows = "vulkan-1.dll";
-        private const string VulkanLibraryNameLinux = "libvulkan.so.1";
-        private const string VulkanLibraryNameMacOS = "libvulkan.dylib";
+        // Platform specific library hints
+        // Win32
+        private static readonly string[] VulkanLibraryNameWindows =
+        {
+            "vulkan-1.dll"
+        };
+
+        // Linux
+        private static readonly string[] VulkanLibraryNameLinux =
+        {
+            "libvulkan.so.1"
+        };
+
+        // macOS: try MoltenVK first (see: https://github.com/KhronosGroup/MoltenVK),
+        // then try libvulkan as a last chance option
+        private static readonly string[] VulkanLibraryNameMacOS =
+        {
+            "libMoltenVk.dylib",
+            "libvulkan.dylib"
+        };
 
         private static string[] _extensions;
 
@@ -34,9 +53,13 @@ namespace SPB.Graphics.Vulkan
             public uint SpecVersion;
         }
 
+        // Extensions related structure type IDs
+        // See: https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_core.h
         private const uint VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR = 1000004000;
         private const uint VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR = 1000005000;
         private const uint VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR = 1000009000;
+        private const uint VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK = 1000123000;
+        private const uint VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT = 1000217000;
 
         private unsafe struct VkWin32SurfaceCreateInfoKHR
         {
@@ -65,14 +88,45 @@ namespace SPB.Graphics.Vulkan
             public IntPtr Window;
         }
 
-        private unsafe delegate int vkEnumerateInstanceExtensionPropertiesDelegate(string layerName, out uint layerCount, VkExtensionProperty* properties);
-        private unsafe delegate int vkCreateWin32SurfaceKHRDelegate(IntPtr instance, ref VkWin32SurfaceCreateInfoKHR createInfo, IntPtr allocator, out IntPtr surface);
-        private unsafe delegate int vkCreateXlibSurfaceKHRDelegate(IntPtr instance, ref VkXlibSurfaceCreateInfoKHR createInfo, IntPtr allocator, out IntPtr surface);
-        private unsafe delegate int vkCreateXcbSurfaceKHRDelegate(IntPtr instance, ref VkXcbSurfaceCreateInfoKHR createInfo, IntPtr allocator, out IntPtr surface);
+        // See: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkMacOSSurfaceCreateInfoMVK.html
+        private unsafe struct VkMacOSSurfaceCreateInfoMVK
+        {
+            public uint StructType; // type of this structure
+            public IntPtr Next; // IntPtr.Zero or pointer to extending structure
+            public uint Flags; // reserved
+            public IntPtr View; // pointer to CAMetalLayer or NSView
+        }
+
+        // See: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateMetalSurfaceEXT.html
+        private unsafe struct VkMetalSurfaceCreateInfoEXT
+        {
+            public uint StructType; // type of this structure
+            public IntPtr Next; // IntPtr.Zero or pointer to extending structure
+            public uint Flags; // reserved
+            public IntPtr View; // pointer to CAMetalLayer
+        }
+
+        private unsafe delegate int vkEnumerateInstanceExtensionPropertiesDelegate(string layerName,
+            out uint layerCount, VkExtensionProperty* properties);
+
+        private unsafe delegate int vkCreateWin32SurfaceKHRDelegate(IntPtr instance,
+            ref VkWin32SurfaceCreateInfoKHR createInfo, IntPtr allocator, out IntPtr surface);
+
+        private unsafe delegate int vkCreateXlibSurfaceKHRDelegate(IntPtr instance,
+            ref VkXlibSurfaceCreateInfoKHR createInfo, IntPtr allocator, out IntPtr surface);
+
+        private unsafe delegate int vkCreateXcbSurfaceKHRDelegate(IntPtr instance,
+            ref VkXcbSurfaceCreateInfoKHR createInfo, IntPtr allocator, out IntPtr surface);
+
+        private unsafe delegate int vkCreateMacOSSurfaceMVKDelegate(IntPtr instance,
+            ref VkMacOSSurfaceCreateInfoMVK createInfo, IntPtr allocator, out IntPtr surface);
+
+        private unsafe delegate int vkCreateMetalSurfaceEXTDelegate(IntPtr instance,
+            ref VkMetalSurfaceCreateInfoEXT createInfo, IntPtr allocator, out IntPtr surface);
 
         private static vkEnumerateInstanceExtensionPropertiesDelegate _vkEnumerateInstanceExtensionProperties;
 
-        private static string GetLibraryName()
+        private static string[] GetLibraryNameHints()
         {
             if (OperatingSystem.IsWindows())
             {
@@ -90,18 +144,33 @@ namespace SPB.Graphics.Vulkan
             return null;
         }
 
+        /// <summary>
+        /// This method attempts to load any suitable Vulkan library.
+        /// If multiple options are available,
+        /// handle to the first successfully loaded library is returned.
+        /// </summary>
+        /// <param name="vulkanHandle">Library handle to set if any library is loaded</param>
+        /// <returns>true if library was successfully loaded, false otherwise</returns>
         private static bool TryLoadLibrary(out IntPtr vulkanHandle)
         {
-            string libraryName = GetLibraryName();
+            var libraryNameHints = GetLibraryNameHints();
+            vulkanHandle = IntPtr.Zero;
 
-            if (libraryName == null)
+            if (libraryNameHints == null)
             {
-                vulkanHandle = IntPtr.Zero;
-
                 return false;
             }
 
-            return NativeLibrary.TryLoad(libraryName, out vulkanHandle);
+            // return on the first successfully loaded library
+            foreach (var libraryName in libraryNameHints)
+            {
+                if (NativeLibrary.TryLoad(libraryName, out vulkanHandle))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool IsExtensionPresent(string extensionName)
@@ -109,7 +178,7 @@ namespace SPB.Graphics.Vulkan
             return _extensions.Contains(extensionName);
         }
 
-        private static unsafe string GetStringFromUtf8Byte(byte *start)
+        private static unsafe string GetStringFromUtf8Byte(byte* start)
         {
             byte* end = start;
             while (*end != 0) end++;
@@ -119,80 +188,96 @@ namespace SPB.Graphics.Vulkan
 
         private static void EnsureInit()
         {
-            if (!_isInit)
+            if (_isInit)
             {
-                if (!TryLoadLibrary(out _vulkanHandle) || !NativeLibrary.TryGetExport(_vulkanHandle, "vkGetInstanceProcAddr", out IntPtr vkGetInstanceProcAddrPtr))
-                {
-                    throw new NotSupportedException("Unsupported platform for Vulkan!");
-                }
-
-
-                _vkGetInstanceProcAddr = Marshal.GetDelegateForFunctionPointer<vkGetInstanceProcAddrDelegate>(vkGetInstanceProcAddrPtr);
-                _vkEnumerateInstanceExtensionProperties = Marshal.GetDelegateForFunctionPointer<vkEnumerateInstanceExtensionPropertiesDelegate>(_vkGetInstanceProcAddr(IntPtr.Zero, "vkEnumerateInstanceExtensionProperties"));
-
-                unsafe
-                {
-                    int res = _vkEnumerateInstanceExtensionProperties(null, out uint layerCount, null);
-
-                    if (res != 0)
-                    {
-                        throw new PlatformException($"vkEnumerateInstanceExtensionProperties failed: {res}");
-                    }
-
-                    VkExtensionProperty[] extensions = new VkExtensionProperty[layerCount];
-
-                    fixed (VkExtensionProperty *extensionsPtr = extensions)
-                    {
-                        res = _vkEnumerateInstanceExtensionProperties(null, out layerCount, extensionsPtr);
-                    }
-
-                    if (res != 0)
-                    {
-                        throw new PlatformException($"vkEnumerateInstanceExtensionProperties failed: {res}");
-                    }
-
-                    _extensions = new string[extensions.Length];
-
-                    for (int i = 0; i < extensions.Length; i++)
-                    {
-                        fixed (byte* extensionNamePtr = extensions[i].ExtensionName)
-                        {
-                            _extensions[i] = GetStringFromUtf8Byte(extensionNamePtr);
-                        }
-                    }
-                }
-
-                // Ensure that all extensions that we are requiring are present.
-
-                bool isVulkanUsable = IsExtensionPresent("VK_KHR_surface");
-
-                if (OperatingSystem.IsWindows())
-                {
-                    isVulkanUsable &= IsExtensionPresent("VK_KHR_win32_surface");
-                }
-                // FIXME: We assume Linux == X11 for now.
-                else if (OperatingSystem.IsLinux())
-                {
-                    if (!IsExtensionPresent("VK_KHR_xcb_surface") || !X11.IsXcbAvailable())
-                    {
-                        if (!IsExtensionPresent("VK_KHR_xlib_surface"))
-                        {
-                            isVulkanUsable = false;
-                        }
-                    }
-                }
-                else if (OperatingSystem.IsMacOS())
-                {
-                    isVulkanUsable &= IsExtensionPresent("VK_MVK_macos_surface");
-                }
-
-                if (!isVulkanUsable)
-                {
-                    throw new NotSupportedException("No supported Vulkan surface found!");
-                }
-
-                _isInit = true;
+                return;
             }
+
+            if (!TryLoadLibrary(out _vulkanHandle) ||
+                !NativeLibrary.TryGetExport(
+                    _vulkanHandle,
+                    "vkGetInstanceProcAddr",
+                    out IntPtr vkGetInstanceProcAddrPtr)
+                )
+            {
+                throw new NotSupportedException("Unsupported platform for Vulkan!");
+            }
+
+
+            _vkGetInstanceProcAddr = Marshal.GetDelegateForFunctionPointer<vkGetInstanceProcAddrDelegate>(
+                vkGetInstanceProcAddrPtr
+            );
+            _vkEnumerateInstanceExtensionProperties =
+                Marshal.GetDelegateForFunctionPointer<vkEnumerateInstanceExtensionPropertiesDelegate>(
+                    _vkGetInstanceProcAddr(IntPtr.Zero, "vkEnumerateInstanceExtensionProperties")
+                );
+
+            unsafe
+            {
+                int res = _vkEnumerateInstanceExtensionProperties(null, out uint layerCount, null);
+
+                if (res != 0)
+                {
+                    throw new PlatformException($"vkEnumerateInstanceExtensionProperties failed: {res}");
+                }
+
+                VkExtensionProperty[] extensions = new VkExtensionProperty[layerCount];
+
+                fixed (VkExtensionProperty* extensionsPtr = extensions)
+                {
+                    res = _vkEnumerateInstanceExtensionProperties(null, out layerCount, extensionsPtr);
+                }
+
+                if (res != 0)
+                {
+                    throw new PlatformException($"vkEnumerateInstanceExtensionProperties failed: {res}");
+                }
+
+                _extensions = new string[extensions.Length];
+
+                for (int i = 0; i < extensions.Length; i++)
+                {
+                    fixed (byte* extensionNamePtr = extensions[i].ExtensionName)
+                    {
+                        _extensions[i] = GetStringFromUtf8Byte(extensionNamePtr);
+                    }
+                }
+            }
+
+            // Ensure that all extensions that we are requiring are present.
+
+            bool isVulkanUsable = IsExtensionPresent("VK_KHR_surface");
+
+            if (OperatingSystem.IsWindows())
+            {
+                isVulkanUsable &= IsExtensionPresent("VK_KHR_win32_surface");
+            }
+            // FIXME: We assume Linux == X11 for now.
+            else if (OperatingSystem.IsLinux())
+            {
+                if (!IsExtensionPresent("VK_KHR_xcb_surface") || !X11.IsXcbAvailable())
+                {
+                    if (!IsExtensionPresent("VK_KHR_xlib_surface"))
+                    {
+                        isVulkanUsable = false;
+                    }
+                }
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                // See:
+                // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_MVK_macos_surface.html
+                // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_metal_surface.html
+                isVulkanUsable &= IsExtensionPresent("VK_MVK_macos_surface") | // deprecated
+                                  IsExtensionPresent("VK_EXT_metal_surface"); // newer extension
+            }
+
+            if (!isVulkanUsable)
+            {
+                throw new NotSupportedException("No supported Vulkan surface found!");
+            }
+
+            _isInit = true;
         }
 
         public static IntPtr GetInstanceProcAddr(IntPtr instance, string name)
@@ -228,88 +313,254 @@ namespace SPB.Graphics.Vulkan
 
             if (OperatingSystem.IsMacOS())
             {
-                extensions.Add("VK_MVK_macos_surface");
+                // prefer a newer extension over deprecated
+                extensions.Add(
+                    IsExtensionPresent("VK_EXT_metal_surface")
+                        ? "VK_EXT_metal_surface"
+                        : "VK_MVK_macos_surface"
+                );
             }
 
             return extensions.ToArray();
         }
 
+        /// <summary>
+        /// This method creates Vulkan surface on Win32 platform.
+        /// </summary>
+        /// <param name="vulkanInstance">Instance of Vulkan library</param>
+        /// <param name="window">Window native handle</param>
+        /// <returns>Reference to surface</returns>
+        /// <exception cref="PlatformException">This exception is raised on surface creation error</exception>
+        private static IntPtr CreateWindowSurfaceWin32(
+            IntPtr vulkanInstance,
+            NativeWindowBase window
+        )
+        {
+            vkCreateWin32SurfaceKHRDelegate vkCreateWin32SurfaceKHR =
+                Marshal.GetDelegateForFunctionPointer<vkCreateWin32SurfaceKHRDelegate>(
+                    _vkGetInstanceProcAddr(vulkanInstance, "vkCreateWin32SurfaceKHR"
+                    )
+                );
+
+            VkWin32SurfaceCreateInfoKHR creationInfo = new VkWin32SurfaceCreateInfoKHR
+            {
+                StructType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
+                Next = IntPtr.Zero,
+                Flags = 0,
+// Broken warning here there is no platform issues here...
+#pragma warning disable CA1416
+                HInstance = Win32.GetWindowLong(
+                    window.WindowHandle.RawHandle,
+                    Win32.GetWindowLongIndex.GWL_HINSTANCE
+                ),
+#pragma warning restore CA1416
+                Hwnd = window.WindowHandle.RawHandle
+            };
+
+            int res = vkCreateWin32SurfaceKHR(
+                vulkanInstance,
+                ref creationInfo,
+                IntPtr.Zero,
+                out IntPtr surface
+            );
+
+            if (res != 0)
+            {
+                throw new PlatformException($"vkCreateWin32SurfaceKHR failed: {res}");
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        /// This method creates Vulkan surface on Linux (XCB) platform.
+        /// </summary>
+        /// <param name="vulkanInstance">Instance of Vulkan library</param>
+        /// <param name="window">Window native handle</param>
+        /// <returns>Reference to surface</returns>
+        /// <exception cref="PlatformException">This exception is raised on surface creation error</exception>
+        [SupportedOSPlatform("linux")]
+        private static IntPtr CreateWindowSurfaceXCB(IntPtr vulkanInstance, NativeWindowBase window)
+        {
+            vkCreateXcbSurfaceKHRDelegate vkCreateXcbSurfaceKHR =
+                Marshal.GetDelegateForFunctionPointer<vkCreateXcbSurfaceKHRDelegate>(
+                    _vkGetInstanceProcAddr(vulkanInstance, "vkCreateXcbSurfaceKHR"
+                    )
+                );
+
+            VkXcbSurfaceCreateInfoKHR creationInfo = new VkXcbSurfaceCreateInfoKHR
+            {
+                StructType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR,
+                Next = IntPtr.Zero,
+                Flags = 0,
+                Connection = X11.GetXCBConnection(window.DisplayHandle.RawHandle),
+                Window = window.WindowHandle.RawHandle
+            };
+
+            int res = vkCreateXcbSurfaceKHR(
+                vulkanInstance,
+                ref creationInfo,
+                IntPtr.Zero,
+                out IntPtr surface
+            );
+
+            if (res != 0)
+            {
+                throw new PlatformException($"vkCreateXcbSurfaceKHR failed: {res}");
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        /// This method creates Vulkan surface on Linux (Xlib) platform.
+        /// </summary>
+        /// <param name="vulkanInstance">Instance of Vulkan library</param>
+        /// <param name="window">Window native handle</param>
+        /// <returns>Reference to surface</returns>
+        /// <exception cref="PlatformException">This exception is raised on surface creation error</exception>
+        private static IntPtr CreateWindowSurfaceXlib(IntPtr vulkanInstance, NativeWindowBase window)
+        {
+            vkCreateXlibSurfaceKHRDelegate vkCreateXlibSurfaceKHR =
+                Marshal.GetDelegateForFunctionPointer<vkCreateXlibSurfaceKHRDelegate>(
+                    _vkGetInstanceProcAddr(vulkanInstance, "vkCreateXlibSurfaceKHR"
+                    )
+                );
+
+            VkXlibSurfaceCreateInfoKHR creationInfo = new VkXlibSurfaceCreateInfoKHR
+            {
+                StructType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR,
+                Next = IntPtr.Zero,
+                Flags = 0,
+                Display = window.DisplayHandle.RawHandle,
+                Window = window.WindowHandle.RawHandle
+            };
+
+            int res = vkCreateXlibSurfaceKHR(
+                vulkanInstance,
+                ref creationInfo,
+                IntPtr.Zero,
+                out IntPtr surface
+            );
+
+            if (res != 0)
+            {
+                throw new PlatformException($"vkCreateXlibSurfaceKHR failed: {res}");
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        /// This method creates Vulkan surface on macOS platform using deprecated MoltenVK extension.
+        /// </summary>
+        /// <param name="vulkanInstance">Instance of Vulkan library</param>
+        /// <param name="window">Window native handle</param>
+        /// <returns>Reference to surface</returns>
+        /// <exception cref="PlatformException">This exception is raised on surface creation error</exception>
+        [SupportedOSPlatform("macos")]
+        private static IntPtr CreateWindowSurfaceMVK(IntPtr vulkanInstance, SimpleCocoaWindow window)
+        {
+            vkCreateMacOSSurfaceMVKDelegate vkCreateMacOSSurfaceMVK =
+                Marshal.GetDelegateForFunctionPointer<vkCreateMacOSSurfaceMVKDelegate>(
+                    _vkGetInstanceProcAddr(vulkanInstance, "vkCreateMacOSSurfaceMVK"
+                    )
+                );
+
+            VkMacOSSurfaceCreateInfoMVK creationInfo = new VkMacOSSurfaceCreateInfoMVK
+            {
+                StructType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK,
+                Next = IntPtr.Zero,
+                Flags = 0,
+                View = window.MetalLayerHandle.RawHandle
+            };
+
+            int res = vkCreateMacOSSurfaceMVK(
+                vulkanInstance,
+                ref creationInfo,
+                IntPtr.Zero,
+                out IntPtr surface
+            );
+
+            if (res != 0)
+            {
+                throw new PlatformException($"vkCreateMacOSSurfaceMVK failed: {res}");
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        /// This method creates Vulkan surface on macOS platform using modern MoltenVK extension.
+        /// </summary>
+        /// <param name="vulkanInstance">Instance of Vulkan library</param>
+        /// <param name="window">Window native handle</param>
+        /// <returns>Reference to surface</returns>
+        /// <exception cref="PlatformException">This exception is raised on surface creation error</exception>
+        [SupportedOSPlatform("macos")]
+        private static IntPtr CreateWindowSurfaceMetal(IntPtr vulkanInstance, SimpleCocoaWindow window)
+        {
+            vkCreateMetalSurfaceEXTDelegate vkCreateMetalSurfaceEXT =
+                Marshal.GetDelegateForFunctionPointer<vkCreateMetalSurfaceEXTDelegate>(
+                    _vkGetInstanceProcAddr(vulkanInstance, "vkCreateMetalSurfaceEXT"
+                    )
+                );
+
+            VkMetalSurfaceCreateInfoEXT creationInfo = new VkMetalSurfaceCreateInfoEXT
+            {
+                StructType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT,
+                Next = IntPtr.Zero,
+                Flags = 0,
+                View = window.MetalLayerHandle.RawHandle
+            };
+
+            int res = vkCreateMetalSurfaceEXT(
+                vulkanInstance,
+                ref creationInfo,
+                IntPtr.Zero,
+                out IntPtr surface
+            );
+
+            if (res != 0)
+            {
+                throw new PlatformException($"vkCreateMetalSurfaceEXT failed: {res}");
+            }
+
+            return surface;
+        }
+
+        /// <summary>
+        /// This method creates Vulkan surface using platform dependent API.
+        /// </summary>
+        /// <param name="vulkanInstance">Instance of Vulkan library</param>
+        /// <param name="window">Window native handle</param>
+        /// <returns>Reference to surface</returns>
+        /// <exception cref="NotImplementedException">This exception is raised if platform is not supported</exception>
         public static IntPtr CreateWindowSurface(IntPtr vulkanInstance, NativeWindowBase window)
         {
             EnsureInit();
 
             if (OperatingSystem.IsWindows() && IsExtensionPresent("VK_KHR_win32_surface"))
             {
-                vkCreateWin32SurfaceKHRDelegate vkCreateWin32SurfaceKHR = Marshal.GetDelegateForFunctionPointer<vkCreateWin32SurfaceKHRDelegate>(_vkGetInstanceProcAddr(vulkanInstance, "vkCreateWin32SurfaceKHR"));
-
-                VkWin32SurfaceCreateInfoKHR creationInfo = new VkWin32SurfaceCreateInfoKHR
-                {
-                    StructType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
-                    Next = IntPtr.Zero,
-                    Flags = 0,
-// Broken warning here there is no platform issues here...
-#pragma warning disable CA1416
-                    HInstance = Win32.GetWindowLong(window.WindowHandle.RawHandle, Win32.GetWindowLongIndex.GWL_HINSTANCE),
-#pragma warning restore CA1416
-                    Hwnd = window.WindowHandle.RawHandle
-                };
-
-                int res = vkCreateWin32SurfaceKHR(vulkanInstance, ref creationInfo, IntPtr.Zero, out IntPtr surface);
-
-                if (res != 0)
-                {
-                    throw new PlatformException($"vkCreateWin32SurfaceKHR failed: {res}");
-                }
-
-                return surface;
+                return CreateWindowSurfaceWin32(vulkanInstance, window);
             }
 
             if (OperatingSystem.IsLinux())
             {
                 if (IsExtensionPresent("VK_KHR_xcb_surface") && X11.IsXcbAvailable())
                 {
-                    vkCreateXcbSurfaceKHRDelegate vkCreateXcbSurfaceKHR = Marshal.GetDelegateForFunctionPointer<vkCreateXcbSurfaceKHRDelegate>(_vkGetInstanceProcAddr(vulkanInstance, "vkCreateXcbSurfaceKHR"));
-
-                    VkXcbSurfaceCreateInfoKHR creationInfo = new VkXcbSurfaceCreateInfoKHR
-                    {
-                        StructType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR,
-                        Next = IntPtr.Zero,
-                        Flags = 0,
-                        Connection = X11.GetXCBConnection(window.DisplayHandle.RawHandle),
-                        Window = window.WindowHandle.RawHandle
-                    };
-
-                    int res = vkCreateXcbSurfaceKHR(vulkanInstance, ref creationInfo, IntPtr.Zero, out IntPtr surface);
-
-                    if (res != 0)
-                    {
-                        throw new PlatformException($"vkCreateXcbSurfaceKHR failed: {res}");
-                    }
-
-                    return surface;
+                    return CreateWindowSurfaceXCB(vulkanInstance, window);
                 }
-                else
-                {
-                    vkCreateXlibSurfaceKHRDelegate vkCreateXlibSurfaceKHR = Marshal.GetDelegateForFunctionPointer<vkCreateXlibSurfaceKHRDelegate>(_vkGetInstanceProcAddr(vulkanInstance, "vkCreateXlibSurfaceKHR"));
 
-                    VkXlibSurfaceCreateInfoKHR creationInfo = new VkXlibSurfaceCreateInfoKHR
-                    {
-                        StructType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR,
-                        Next = IntPtr.Zero,
-                        Flags = 0,
-                        Display = window.DisplayHandle.RawHandle,
-                        Window = window.WindowHandle.RawHandle
-                    };
+                return CreateWindowSurfaceXlib(vulkanInstance, window);
+            }
 
-                    int res = vkCreateXlibSurfaceKHR(vulkanInstance, ref creationInfo, IntPtr.Zero, out IntPtr surface);
-
-                    if (res != 0)
-                    {
-                        throw new PlatformException($"vkCreateXlibSurfaceKHR failed: {res}");
-                    }
-
-                    return surface;
-                }
+            if (OperatingSystem.IsMacOS())
+            {
+                var cocoaWindow = (SimpleCocoaWindow)window;
+                return IsExtensionPresent("VK_EXT_metal_surface")
+                    ? CreateWindowSurfaceMetal(vulkanInstance, cocoaWindow)
+                    : CreateWindowSurfaceMVK(vulkanInstance, cocoaWindow);
             }
 
             throw new NotImplementedException();

--- a/SPB/Platform/Cocoa/ObjectiveC.cs
+++ b/SPB/Platform/Cocoa/ObjectiveC.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SPB.Platform.Cocoa;
+
+/// <summary>
+/// This class provides basic interaction with ObjectiveC runtime.
+/// See: https://developer.apple.com/documentation/objectivec/objective-c_runtime
+/// </summary>
+internal class ObjectiveC
+{
+    // In NET6+ this should be easier with updated interop services
+    private const string LibraryName = "libobjc.dylib";
+
+    [DllImport(LibraryName, CharSet = CharSet.Ansi)]
+    private static extern IntPtr objc_getClass(string className);
+
+    [DllImport(LibraryName, CharSet = CharSet.Ansi)]
+    private static extern IntPtr sel_getUid(string selector);
+
+    [DllImport(LibraryName, CharSet = CharSet.Ansi)]
+    private static extern string object_getClass(IntPtr obj);
+
+    [DllImport(LibraryName)]
+    private static extern IntPtr objc_msgSend(IntPtr self, IntPtr selector);
+
+    [DllImport(LibraryName, EntryPoint = "objc_msgSend")]
+    private static extern bool bool_msgSend_IntPtr(IntPtr self, IntPtr selector, IntPtr arg);
+
+    [DllImport(LibraryName, EntryPoint = "objc_msgSend")]
+    private static extern void void_msgSend_IntPtr(IntPtr self, IntPtr selector, IntPtr arg);
+
+    [DllImport(LibraryName, EntryPoint = "objc_msgSend")]
+    private static extern void void_msgSend_void(IntPtr self, IntPtr selector);
+
+    [DllImport(LibraryName, EntryPoint = "objc_msgSend")]
+    private static extern void void_msgSend_bool(IntPtr self, IntPtr selector, bool arg);
+
+    /// <summary>
+    /// This method checks if a given object is of expected class and throws
+    /// ArgumentException if it is not.
+    /// </summary>
+    /// <param name="obj">Object to check class</param>
+    /// <param name="className">Class name, e.g. 'NSWindow'</param>
+    /// <exception cref="ArgumentException">Is thrown if obj is not an instance of class className</exception>
+    internal static void EnsureIsKindOfClass(IntPtr obj, string className)
+    {
+        if (IsKindOfClass(obj, className))
+        {
+            return;
+        }
+
+        var objClassName = GetObjectClassName(obj);
+        throw new ArgumentException(
+            $"Object is of type '{objClassName}' instead of expected '{className}'"
+        );
+    }
+
+    /// <summary>
+    /// This method checks if a given object is of expected class specified by its string name.
+    /// </summary>
+    /// <param name="obj">Object to check class</param>
+    /// <param name="className">Class name, e.g. 'NSWindow'</param>
+    /// <returns>true if object type matches class, false otherwise</returns>
+    internal static bool IsKindOfClass(IntPtr obj, string className)
+    {
+        if (obj == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        var klass = GetClass(className, false);
+
+        if (klass == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        var selector = GetSelector("isKindOfClass:");
+        return bool_msgSend_IntPtr(obj, selector, klass);
+    }
+
+    /// <summary>
+    /// This method returns class name for an object.
+    /// </summary>
+    /// <param name="obj">Instance to get class name for</param>
+    /// <returns>Name of class for a given object instance</returns>
+    private static string GetObjectClassName(IntPtr obj)
+    {
+        return object_getClass(obj);
+    }
+
+    /// <summary>
+    /// Returns type for class specified by its name.
+    /// </summary>
+    /// <param name="className">Class name, e.g. 'NSWindow'</param>
+    /// <param name="throwOnUnknownName">Indicates need to raise exception if class name is not known</param>
+    /// <returns>Class type as IntPtr reference</returns>
+    /// <exception cref="ArgumentException">This exception is raised if class name is not known</exception>
+    internal static IntPtr GetClass(string className, bool throwOnUnknownName = true)
+    {
+        var result = objc_getClass(className);
+
+        if (throwOnUnknownName && result == IntPtr.Zero)
+        {
+            throw new ArgumentException($"No such class '{className}'");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// This method returns selector by its name.
+    /// </summary>
+    /// <param name="selectorName">Name of selector, e.g. 'layer:'</param>
+    /// <returns>Selector as IntPtr reference</returns>
+    /// <exception cref="ArgumentException">This exception is raised if selector name is not known</exception>
+    private static IntPtr GetSelector(string selectorName)
+    {
+        var selector = sel_getUid(selectorName);
+
+        if (selector != IntPtr.Zero)
+        {
+            return selector;
+        }
+
+        throw new ArgumentException(
+            $"Can not get selector '{selectorName}'"
+        );
+    }
+
+    /// <summary>
+    /// This method sends message that object responds with IntPtr.
+    /// </summary>
+    /// <param name="obj">Object to send message to</param>
+    /// <param name="selectorName">Name of selector for the message</param>
+    /// <returns>IntPtr value as responded by object</returns>
+    internal static IntPtr GetIntPtrValue(IntPtr obj, string selectorName)
+    {
+        var selector = GetSelector(selectorName);
+        return objc_msgSend(obj, selector);
+    }
+
+    /// <summary>
+    /// This method sends message to set object property to IntPtr value.
+    /// </summary>
+    /// <param name="obj">Object to send message to</param>
+    /// <param name="selectorName">Name of selector for the message</param>
+    /// <param name="value">Value to set</param>
+    internal static void SetIntPtrValue(IntPtr obj, string selectorName, IntPtr value)
+    {
+        var selector = GetSelector(selectorName);
+        void_msgSend_IntPtr(obj, selector, value);
+    }
+
+    /// <summary>
+    /// This method sends message to set object property to boolean value.
+    /// </summary>
+    /// <param name="obj">Object to send message to</param>
+    /// <param name="selectorName">Name of selector for the message</param>
+    /// <param name="value">Value to set</param>
+    internal static void SetBoolValue(IntPtr obj, string selectorName, bool value)
+    {
+        var selector = GetSelector(selectorName);
+        void_msgSend_bool(obj, selector, value);
+    }
+
+    /// <summary>
+    /// This method sends message to invoke object method without any arguments
+    /// or return value.
+    /// </summary>
+    /// <param name="obj">Object to send message to</param>
+    /// <param name="selectorName">Name of selector for the message</param>
+    internal static void InvokeVoid(IntPtr obj, string selectorName)
+    {
+        var selector = GetSelector(selectorName);
+        void_msgSend_void(obj, selector);
+    }
+}

--- a/SPB/Platform/Cocoa/SimpleCocoaWindow.cs
+++ b/SPB/Platform/Cocoa/SimpleCocoaWindow.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Runtime.Versioning;
+using SPB.Platform.Exceptions;
+using SPB.Windowing;
+
+namespace SPB.Platform.Cocoa;
+
+/// <summary>
+/// Provides implementation for bindings to NSWindow class on macOS.
+/// </summary>
+[SupportedOSPlatform("macos")]
+public class SimpleCocoaWindow : NativeWindowBase
+{
+    // NSWindow pointer wrapper
+    public override NativeHandle WindowHandle { get; }
+
+    // CAMetalLayer pointer wrapper
+    public NativeHandle MetalLayerHandle { get; private set; }
+
+    public override NativeHandle DisplayHandle => throw new NotImplementedException();
+
+    /// <summary>
+    /// Constructs instance of this class.
+    /// </summary>
+    /// <param name="windowHandle">NSWindow native pointer</param>
+    /// <param name="initMetalLayer">Flag indicating need to acquire Metal layer</param>
+    public SimpleCocoaWindow(NativeHandle windowHandle, bool initMetalLayer = true)
+    {
+        WindowHandle = windowHandle;
+
+        // Sanity check
+        ObjectiveC.EnsureIsKindOfClass(windowHandle.RawHandle, "NSWindow");
+
+        if (initMetalLayer)
+        {
+            InitMetalLayer();
+        }
+    }
+
+    private void InitMetalLayer()
+    {
+        // assuming that handles is NSWindow
+        // 1. get top-level NSView
+        // 2. get its layer
+        // 3. if it is CAMetalLayer, we have what we need
+        // 4. make it CAMetalLayer
+
+        // 1. get top-level NSView
+        var contentView = ObjectiveC.GetIntPtrValue(WindowHandle.RawHandle, "contentView");
+
+        ObjectiveC.EnsureIsKindOfClass(contentView, "NSView");
+
+        // 2. get its layer
+        var layer = ObjectiveC.GetIntPtrValue(contentView, "layer");
+
+        // 3. if it is CAMetalLayer, we have what we need
+        if (ObjectiveC.IsKindOfClass(contentView, "CAMetalLayer"))
+        {
+            MetalLayerHandle = new NativeHandle(layer);
+            return;
+        }
+
+        // 4. make it CAMetalLayer
+        // https://developer.apple.com/documentation/quartzcore/cametallayer?language=objc
+        Console.Out.WriteLine("Replacing original NSView layer with CAMetalLayer");
+
+        var layerClass = ObjectiveC.GetClass("CAMetalLayer");
+        var metalLayer = ObjectiveC.GetIntPtrValue(layerClass, "layer");
+        MetalLayerHandle = new NativeHandle(metalLayer);
+
+        ObjectiveC.SetBoolValue(contentView, "wantsLayer", true);
+        ObjectiveC.SetIntPtrValue(contentView, "setLayer:", metalLayer);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        // Do nothing as no actual resource is owned
+    }
+
+    public override void Show()
+    {
+        if (WindowHandle.RawHandle == IntPtr.Zero)
+        {
+            throw new PlatformException("Attempted to show not initialised window");
+        }
+
+        // [self makeKeyAndOrderFront:self];
+        ObjectiveC.SetIntPtrValue(
+            WindowHandle.RawHandle,
+            "makeKeyAndOrderFront:",
+            WindowHandle.RawHandle
+        );
+    }
+
+    public override void Hide()
+    {
+        if (WindowHandle.RawHandle == IntPtr.Zero)
+        {
+            throw new PlatformException("Attempted to hide not initialised window");
+        }
+
+        // [self orderOut:self];
+        ObjectiveC.SetIntPtrValue(
+            WindowHandle.RawHandle,
+            "orderOut:",
+            WindowHandle.RawHandle
+        );
+    }
+}


### PR DESCRIPTION
## Overview
This PR updates `VulkanHelper` class to support creation of surfaces on macOS and introduces `SimpleCocoaWindow` to work with `NSWindow`.

`VulkanHelper` changes:
* adds methods to create Vulkan surface on macOS using both deprecated and newer Vulkan extensions;
* alters Vulkan library loading to try [MoltenVk](https://github.com/KhronosGroup/MoltenVK) first, then generic `libvulkan`;
* slightly refactors `CreateWindowSurface()` method to split it into a set of platform specific methods and thus reduce complexity a bit.

`SimpleCocoaWindow`:
* is macOS only, does not support CocoaTouch;
* uses a basic Objective-C runtime interop layer to invoke methods on classes like `NSView` and `NSWindow`.

## Testing
I've written this while trying to make Ryujinx workable on macOS after fixing JIT memory access issues on M1.

Unfortunately Ryujinx requires Vulkan extensions that are not implemented by MoltenVk. So logic is tested by running Ryujinx up to the moment where it checks extensions and throws error on failure to find `VK_EXT_transform_feedback` not implemented by [MoltenVk](https://github.com/KhronosGroup/MoltenVK/issues/1588). This means that initialisation logic in `VulkanHelper` itself works fine and devices enumeration, extensions enumeration, etc in Ryujinx have no issues.